### PR TITLE
feat: add AI-driven commit helper with language options

### DIFF
--- a/make_commit
+++ b/make_commit
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
+import argparse
+import os
 import subprocess
+
+import openai
 
 def run(cmd: str) -> str:
     try:
@@ -33,19 +37,69 @@ def get_diff_stats():
         total_del += deleted
     return stats, total_add, total_del
 
+def generate_commit_message(stats, total_add, total_del, lang: str) -> str:
+    """Generate a commit message using OpenAI."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    openai.api_key = api_key
+
+    stats_text = "\n".join(
+        f"{filename}: +{added} -{deleted}" for filename, added, deleted in stats
+    )
+    language = "Korean" if lang == "ko" else "English"
+    prompt = (
+        f"Write a concise git commit message in {language} using the conventional commit "
+        "style such as feat, fix, refactor, or chore based on the following changes:\n"
+        f"{stats_text}\nTotal additions: {total_add}, deletions: {total_del}."
+    )
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {
+                "role": "system",
+                "content": "You are an assistant that writes git commit messages.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.5,
+        max_tokens=60,
+    )
+    return response["choices"][0]["message"]["content"].strip()
+
+
 def main():
+    parser = argparse.ArgumentParser(description="AI-powered git commit helper")
+    parser.add_argument(
+        "-e", action="store_true", help="Generate commit message in English"
+    )
+    parser.add_argument(
+        "-k", action="store_true", help="Generate commit message in Korean"
+    )
+    args = parser.parse_args()
+
+    lang = "ko"
+    if args.e:
+        lang = "en"
+    elif args.k:
+        lang = "ko"
+
     files = get_staged_files()
     if not files:
         print("스테이징된 변경사항이 없습니다.")
         return
+
     stats, total_add, total_del = get_diff_stats()
-    file_list = ', '.join(files)
-    basic_version = f"{file_list} 파일에 {total_add}줄 추가, {total_del}줄 삭제"
-    concise_version = f"{file_list} 업데이트"
-    feature_version = f"{file_list} 관련 기능 개선"
-    print("기본버전:", basic_version)
-    print("간결한 버전:", concise_version)
-    print("기능중심버전:", feature_version)
+    try:
+        message = generate_commit_message(stats, total_add, total_del, lang)
+    except Exception as e:
+        print(f"AI 기반 커밋 메시지를 생성할 수 없습니다: {e}")
+        return
+
+    subprocess.run(["git", "commit", "-m", message])
+    print("생성된 커밋 메시지:")
+    print(message)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- integrate OpenAI to produce commit messages
- add flags for Korean or English commit message generation
- commit with AI-generated conventional message

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfe6094570832ba0e7cf454f844900